### PR TITLE
Support the newer getUserMedia method

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,13 @@ navigator.mediaDevices.enumerateDevices().then(function(devices) {
     bpm = document.getElementById("bpm");
     
     // Get the webcam's stream.
-    navigator.getUserMedia(constraints, startStream, function () {});
+    if (navigator.mediaDevices.getUserMedia) {
+      navigator.mediaDevices.getUserMedia(constraints)
+        .then(startStream)
+        .catch(console.error)
+    } else {
+      navigator.getUserMedia(constraints, startStream, function () {});
+    }
   }
 
   function startStream(stream) {


### PR DESCRIPTION
The `navigator.getUserMedia` [is obsolete](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getUserMedia).

This request uses [the new method](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia) if it's defined.